### PR TITLE
Point out where these can be seen online

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This iPython Notebook was built with iPython 3.2.1. A similar version of iPython
 
 # Viewing
 
+## Online
+
+These slides can be viewed online by simply visiting this URL ( <http://nbviewer.ipython.org/format/slides/github/DudLab/git_ready/blob/master/slides.ipynb#/> )
+
+## Offline
+
 To get a working copy of the slides locally, install the requirements and run the following command inside the directory.
 
 ```


### PR DESCRIPTION
Thankfully, http://nbviewer.ipython.org/ can render these slides for us online using our GitHub repo alone. Make a note of the URL to follow and do so.
